### PR TITLE
Assembler_UAL_Register

### DIFF
--- a/Assembler_UAL_Register
+++ b/Assembler_UAL_Register
@@ -1,0 +1,85 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity assembledUalReg is
+    port (
+        op : in std_logic_vector(1 downto 0);
+        a, b : in std_logic_vector(31 downto 0);
+        we : in std_logic;
+        ra, rb, rw : in std_logic_vector(3 downto 0);
+        w_clk, r_clk, rst : in std_logic;
+        s : out std_logic_vector(31 downto 0);
+        n : out std_logic;
+        A, B : out std_logic_vector(31 downto 0)
+    );
+end entity assembledUalReg;
+
+architecture behavior of assembledUalReg is
+    signal W : std_logic_vector(31 downto 0);
+    signal RA, RB, RW : std_logic_vector(3 downto 0);
+    signal WE : std_logic;
+    signal A, B : std_logic_vector(31 downto 0);
+
+    component ual is
+        port (
+            op : in std_logic_vector(1 downto 0);
+            a, b : in std_logic_vector(31 downto 0);
+            s : out std_logic_vector(31 downto 0);
+            n : out std_logic
+        );
+    end component;
+
+    component RegisterBank is
+        port (
+            CLK, RST : in std_logic;
+            W : in std_logic_vector (31 downto 0);
+            RA, RB, RW : in std_logic_vector (3 downto 0);
+            WE : in std_logic;
+            A, B : out std_logic_vector (31 downto 0)
+        );
+    end component;
+
+begin
+    UAL_inst : ual
+        port map (
+            op => op,
+            a => a,
+            b => b,
+            s => s,
+            n => n
+        );
+
+    REG_inst : RegisterBank
+        port map (
+            CLK => r_clk,
+            RST => rst,
+            W => W,
+            RA => RA,
+            RB => RB,
+            RW => RW,
+            WE => WE,
+            A => A,
+            B => B
+        );
+
+    -- Connect the write clock and reset signals to the RegisterBank
+    w_clk <= r_clk;
+    rst <= RST;
+
+    -- Connect the input signals to the write data and write address buses
+    W <= s;
+    RW <= ra;
+
+    -- Connect the input signals to the read address buses
+    RA <= ra;
+    RB <= rb;
+
+    -- Connect the write enable signal to the WE input of the RegisterBank
+    WE <= we;
+
+    -- Connect the output signals to the A and B outputs of the RegisterBank
+    A <= A;
+    B <= B;
+
+end architecture behavior;


### PR DESCRIPTION
library ieee;
use ieee.std_logic_1164.all;
use ieee.numeric_std.all;

entity assembledUalReg is
    port (
        op : in std_logic_vector(1 downto 0);
        a, b : in std_logic_vector(31 downto 0);
        we : in std_logic;
        ra, rb, rw : in std_logic_vector(3 downto 0);
        w_clk, r_clk, rst : in std_logic;
        s : out std_logic_vector(31 downto 0);
        n : out std_logic;
        A, B : out std_logic_vector(31 downto 0)
    );
end entity assembledUalReg;

architecture behavior of assembledUalReg is
    signal W : std_logic_vector(31 downto 0);
    signal RA, RB, RW : std_logic_vector(3 downto 0);
    signal WE : std_logic;
    signal A, B : std_logic_vector(31 downto 0);

    component ual is
        port (
            op : in std_logic_vector(1 downto 0);
            a, b : in std_logic_vector(31 downto 0);
            s : out std_logic_vector(31 downto 0);
            n : out std_logic
        );
    end component;

    component assembledUalReg is
        port (
            CLK, RST : in std_logic;
            W : in std_logic_vector (31 downto 0);
            RA, RB, RW : in std_logic_vector (3 downto 0);
            WE : in std_logic;
            A, B : out std_logic_vector (31 downto 0)
        );
    end component;

begin
    UAL_inst : ual
        port map (
            op => op,
            a => a,
            b => b,
            s => s,
            n => n
        );

    REG_inst : assembledUalReg
        port map (
            CLK => r_clk,
            RST => rst,
            W => W,
            RA => RA,
            RB => RB,
            RW => RW,
            WE => WE,
            A => A,
            B => B
        );

    w_clk <= r_clk;
    rst <= RST;

    W <= s;
    RW <= ra;

    RA <= ra;
    RB <= rb;

    WE <= we;

    A <= A;
    B <= B;

end architecture behavior;